### PR TITLE
Make riverbed links more idempotent

### DIFF
--- a/app/controllers/riverbed/links_controller.rb
+++ b/app/controllers/riverbed/links_controller.rb
@@ -9,8 +9,7 @@ module Riverbed
       )
 
       attributes = {
-        url_field_id => parsed_link.canonical,
-        title_field_id => link_params["field-values"][title_field_id]
+        url_field_id => parsed_link.canonical
       }
       attributes[title_field_id] = parsed_link.title if default_title?(link_params)
       attributes[saved_at_field_id] = now if link_params["field-values"][saved_at_field_id].blank?

--- a/app/controllers/riverbed/links_controller.rb
+++ b/app/controllers/riverbed/links_controller.rb
@@ -10,11 +10,11 @@ module Riverbed
 
       attributes = {
         url_field_id => parsed_link.canonical,
-        title_field_id => link_params["field-values"][title_field_id],
-        field_id("Saved At") => now,
-        field_id("Read Status Changed At") => now
+        title_field_id => link_params["field-values"][title_field_id]
       }
       attributes[title_field_id] = parsed_link.title if default_title?(link_params)
+      attributes[saved_at_field_id] = now if link_params["field-values"][saved_at_field_id].blank?
+      attributes[read_status_changed_at_field] = now if link_params["field-values"][read_status_changed_at_field].blank?
 
       render json: attributes
     end
@@ -39,6 +39,10 @@ module Riverbed
     def url_field_id = field_id("URL")
 
     def title_field_id = field_id("Title")
+
+    def saved_at_field_id = field_id("Saved At")
+
+    def read_status_changed_at_field = field_id("Read Status Changed At")
 
     def link_parser = LinkParser
 

--- a/app/controllers/riverbed/links_controller.rb
+++ b/app/controllers/riverbed/links_controller.rb
@@ -3,15 +3,17 @@ require "link_parser"
 module Riverbed
   class LinksController < ApplicationController
     def update
-      parsed_link = link_parser.process(
-        url: link_params["field-values"][url_field_id],
-        timeout_seconds: 30
-      )
+      attributes = {}
 
-      attributes = {
-        url_field_id => parsed_link.canonical
-      }
-      attributes[title_field_id] = parsed_link.title if default_title?(link_params)
+      if default_title?(link_params)
+        parsed_link = link_parser.process(
+          url: link_params["field-values"][url_field_id],
+          timeout_seconds: 30
+        )
+        attributes[title_field_id] = parsed_link.title
+        attributes[url_field_id] = parsed_link.canonical
+      end
+
       attributes[saved_at_field_id] = now if link_params["field-values"][saved_at_field_id].blank?
       attributes[read_status_changed_at_field] = now if link_params["field-values"][read_status_changed_at_field].blank?
 

--- a/lib/fake_link_parser.rb
+++ b/lib/fake_link_parser.rb
@@ -22,7 +22,7 @@ class FakeLinkParser
   end
 
   def canonical
-    url
+    "#{url}/"
   end
 
   private

--- a/spec/requests/riverbed/links_controller_spec.rb
+++ b/spec/requests/riverbed/links_controller_spec.rb
@@ -46,12 +46,12 @@ RSpec.describe "riverbed links", type: :request do
       }
     }
 
-    it "returns a record with the retrieved title" do
+    it "returns a record with the retrieved title and canonical URL" do
       send!
 
       expect(response.status).to eq(200)
       expect(response_body).to eq({
-        url_field["id"] => url,
+        url_field["id"] => "#{url}/",
         title_field["id"] => "Sample Post Title",
         saved_at_field["id"] => now,
         read_status_changed_at_field["id"] => now
@@ -72,7 +72,7 @@ RSpec.describe "riverbed links", type: :request do
 
       expect(response.status).to eq(200)
       expect(response_body).to eq({
-        url_field["id"] => url,
+        url_field["id"] => "#{url}/",
         saved_at_field["id"] => now,
         read_status_changed_at_field["id"] => now
       })
@@ -95,7 +95,7 @@ RSpec.describe "riverbed links", type: :request do
 
       expect(response.status).to eq(200)
       expect(response_body).to eq({
-        url_field["id"] => url
+        url_field["id"] => "#{url}/"
       })
     end
   end

--- a/spec/requests/riverbed/links_controller_spec.rb
+++ b/spec/requests/riverbed/links_controller_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe "riverbed links", type: :request do
   }
   let(:response_body) { JSON.parse(response.body) }
   let(:now) { Time.zone.now.iso8601 }
+  let(:title) { "Pre-Set Title" }
 
   before(:each) do
     LinkParser.fake!
@@ -59,7 +60,6 @@ RSpec.describe "riverbed links", type: :request do
   end
 
   context "with a pre-set title" do
-    let(:title) { "Pre-Set Title" }
     let(:field_values) {
       {
         url_field["id"] => url,
@@ -76,6 +76,28 @@ RSpec.describe "riverbed links", type: :request do
         title_field["id"] => title,
         saved_at_field["id"] => now,
         read_status_changed_at_field["id"] => now
+      })
+    end
+  end
+
+  context "with date fields present" do
+    let(:earlier) { 1.day.ago.iso8601 }
+    let(:field_values) {
+      {
+        url_field["id"] => url,
+        title_field["id"] => title,
+        saved_at_field["id"] => earlier,
+        read_status_changed_at_field["id"] => earlier
+      }
+    }
+
+    it "does not overwrite the date fields" do
+      send!
+
+      expect(response.status).to eq(200)
+      expect(response_body).to eq({
+        url_field["id"] => url,
+        title_field["id"] => title
       })
     end
   end

--- a/spec/requests/riverbed/links_controller_spec.rb
+++ b/spec/requests/riverbed/links_controller_spec.rb
@@ -67,13 +67,12 @@ RSpec.describe "riverbed links", type: :request do
       }
     }
 
-    it "returns a record with the pre-set title" do
+    it "does not override the pre-set title" do
       send!
 
       expect(response.status).to eq(200)
       expect(response_body).to eq({
         url_field["id"] => url,
-        title_field["id"] => title,
         saved_at_field["id"] => now,
         read_status_changed_at_field["id"] => now
       })
@@ -96,8 +95,7 @@ RSpec.describe "riverbed links", type: :request do
 
       expect(response.status).to eq(200)
       expect(response_body).to eq({
-        url_field["id"] => url,
-        title_field["id"] => title
+        url_field["id"] => url
       })
     end
   end

--- a/spec/requests/riverbed/links_controller_spec.rb
+++ b/spec/requests/riverbed/links_controller_spec.rb
@@ -67,12 +67,11 @@ RSpec.describe "riverbed links", type: :request do
       }
     }
 
-    it "does not override the pre-set title" do
+    it "does not override the pre-set title or url" do
       send!
 
       expect(response.status).to eq(200)
       expect(response_body).to eq({
-        url_field["id"] => "#{url}/",
         saved_at_field["id"] => now,
         read_status_changed_at_field["id"] => now
       })
@@ -94,9 +93,7 @@ RSpec.describe "riverbed links", type: :request do
       send!
 
       expect(response.status).to eq(200)
-      expect(response_body).to eq({
-        url_field["id"] => "#{url}/"
-      })
+      expect(response_body).to eq({})
     end
   end
 end


### PR DESCRIPTION
- Don't return fields that aren't changing
- Only set date fields if they aren't present
- Don't access URL (even for canonical URL) unless title needs to be set